### PR TITLE
增加jobs列表页根据标题前缀城市筛选的功能

### DIFF
--- a/app/controllers/homeland/jobs/jobs_controller.rb
+++ b/app/controllers/homeland/jobs/jobs_controller.rb
@@ -8,6 +8,7 @@ module Homeland::Jobs
       @topics = Topic.where(node_id: @node.id)
       @topics = @topics.where.not(id: suggest_topic_ids) if suggest_topic_ids.count > 0
       @topics = @topics.last_actived.includes(:user).page(params[:page])
+      @topics = @topics.where("title LIKE ?", "%[#{params[:location]}]%") if params[:location]
       @page_title = '招聘'
       render '/topics/index' if stale?(etag: [@node, @suggest_topics, @topics], template: '/topics/index')
     end


### PR DESCRIPTION
#### 实现：

通过匹配~~热门城市列表和~~招聘板标题的 [城市] 前缀来进一步筛选 @topics 的 scope。

选择热门城市列表的原因是考虑，在 Ruby China 上某座城市的求职 / 招聘帖的数量和此城市的注册用户数应该是正相关的。

~~路由方面参考了 ruby-china.org/users/city/北京 来进行处理。~~


#### 需求：

起因是自己在使用招聘版的时候一直感觉有些不便……当求职者在某个城市求职时，经常会有只想查看这座城市的招聘贴的情况。

##### p.s.

初学者中的初学者，如果哪里做的不好或不对还望能不吝赐教一下，万分感谢！